### PR TITLE
Add twitter heatmap to homepage

### DIFF
--- a/sitio/src/lib/HeatmapHours.svelte
+++ b/sitio/src/lib/HeatmapHours.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+  export let matrix: number[][]; // 7 x 24, dayjs().day() indexing (0=Sunday)
+  export let title: string = "Horas típicas de actividad (UTC-3)";
+
+  const weekdays = [
+    "Dom",
+    "Lun",
+    "Mar",
+    "Mié",
+    "Jue",
+    "Vie",
+    "Sáb",
+  ];
+
+  const hours = Array.from({ length: 24 }, (_, h) => h);
+
+  $: max = Math.max(0, ...matrix.flat());
+
+  function colorFor(value: number) {
+    if (max === 0) return "#e5e7eb"; // neutral-200
+    const t = value / max;
+    // simple sequential palette from light to dark orange
+    if (t === 0) return "#f3f4f6"; // neutral-100
+    if (t < 0.2) return "#fde7d9";
+    if (t < 0.4) return "#fdcdb3";
+    if (t < 0.6) return "#fca36b";
+    if (t < 0.8) return "#f77f00";
+    return "#d65a00";
+  }
+</script>
+
+<div class="flex w-full flex-col gap-3">
+  <div class="flex items-center justify-between">
+    <h3 class="text-lg font-semibold">{title}</h3>
+    <span class="text-xs text-muted-foreground">Zona horaria: UTC-3</span>
+  </div>
+
+  <div class="overflow-x-auto">
+    <div class="grid" style="grid-template-columns: 48px repeat(24, minmax(20px,1fr));">
+      <div></div>
+      {#each hours as h}
+        <div class="text-center text-[10px] text-muted-foreground">{h}</div>
+      {/each}
+
+      {#each matrix as row, dow}
+        <div class="sticky left-0 z-10 bg-transparent pr-2 text-right text-xs">{weekdays[dow]}</div>
+        {#each row as value}
+          <div class="aspect-square border border-neutral-200 dark:border-neutral-700" style={`background:${colorFor(value)}`}
+            title={`${weekdays[dow]} ${value} interacciones`}></div>
+        {/each}
+      {/each}
+    </div>
+  </div>
+
+  <div class="flex items-center gap-2 self-end text-xs text-muted-foreground">
+    <span>menos</span>
+    <div class="h-3 w-3" style="background:#f3f4f6"></div>
+    <div class="h-3 w-3" style="background:#fde7d9"></div>
+    <div class="h-3 w-3" style="background:#fdcdb3"></div>
+    <div class="h-3 w-3" style="background:#fca36b"></div>
+    <div class="h-3 w-3" style="background:#f77f00"></div>
+    <div class="h-3 w-3" style="background:#d65a00"></div>
+    <span>más</span>
+  </div>
+</div>
+

--- a/sitio/src/routes/+page.svelte
+++ b/sitio/src/routes/+page.svelte
@@ -36,6 +36,7 @@
   import { parseDate } from "@internationalized/date";
   import StatsCalendar from "@/StatsCalendar.svelte";
   import StatsCalendarNavigation from "@/StatsCalendarNavigation.svelte";
+  import HeatmapHours from "$lib/HeatmapHours.svelte";
 
   export let data: PageData;
 
@@ -166,6 +167,18 @@
           </span>
         </div>
       </div>
+    </div>
+  </section>
+
+  <section class="mx-auto w-full max-w-2xl">
+    <div class="mx-2 my-4 rounded-lg bg-neutral-100 p-4 dark:bg-neutral-800">
+      <h2 class="mb-2 text-center text-xl font-bold md:text-3xl">
+        ¿Cuándo suele estar activo en Twitter? (UTC-3)
+      </h2>
+      <p class="mb-4 text-center text-sm text-muted-foreground">
+        Basado en retweets y likes de los últimos 60 días.
+      </p>
+      <HeatmapHours matrix={data.hourHeatmap} />
     </div>
   </section>
 


### PR DESCRIPTION
Add a heatmap of typical Twitter activity times in UTC-3 to the homepage to visualize user engagement patterns.

---
<a href="https://cursor.com/background-agent?bcId=bc-bd3b6079-2b76-4c11-b1fb-206d5f102d05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bd3b6079-2b76-4c11-b1fb-206d5f102d05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

